### PR TITLE
Updating SHA256 checksum to match version 1.5.2

### DIFF
--- a/azure-data-studio.nuspec
+++ b/azure-data-studio.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>azure-data-studio</id>
     <title>Azure Data Studio</title>
-    <version>1.5.1</version>
+    <version>1.5.2</version>
     <authors>Microsoft</authors>
     <owners>kendaleiv</owners>
     <summary>Azure Data Studio</summary>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -12,7 +12,7 @@ $packageArgs = @{
 
   softwareName   = 'Azure Data Studio'
 
-  checksum64     = '153BF594089CBC51D675702C4E4B575D8F71B75D2958FB456D6B4BC1576E18B8'
+  checksum64     = 'CE02B5B0B9D7A500E5D5DB1790290237C830B10A5990FCFFF9B7E7FCE56BEC34'
   checksumType64 = 'sha256'
 
   silentArgs     = "/verysilent /suppressmsgboxes /mergetasks=""$mergeTasks"" /log=""$env:temp\azure-data-studio.log"""

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -12,7 +12,7 @@ $packageArgs = @{
 
   softwareName   = 'Azure Data Studio'
 
-  checksum64     = 'CE02B5B0B9D7A500E5D5DB1790290237C830B10A5990FCFFF9B7E7FCE56BEC34'
+  checksum64     = '01CE71522FFAA8982502EBAA68E5EF6B97A6B679379C59916067EA495C8A2000'
   checksumType64 = 'sha256'
 
   silentArgs     = "/verysilent /suppressmsgboxes /mergetasks=""$mergeTasks"" /log=""$env:temp\azure-data-studio.log"""


### PR DESCRIPTION
Version 1.5.2 was released on 3/22/2019. New checksum was grabbed from PowerShell via `(Get-FileHash .\azuredatastudio-windows-setup-1.5.2.exe -Algorithm SHA256).Hash`