### PR TITLE
Fix package tag

### DIFF
--- a/azure-data-studio.nuspec
+++ b/azure-data-studio.nuspec
@@ -15,7 +15,7 @@
     <iconUrl>https://cdn.rawgit.com/kendaleiv/chocolatey-azure-data-studio/12c5988a/logo.png</iconUrl>
     <licenseUrl>https://github.com/Microsoft/azuredatastudio/blob/master/LICENSE.txt</licenseUrl>
     <bugTrackerUrl>https://github.com/Microsoft/azuredatastudio/issues</bugTrackerUrl>
-    <tags>azure data studio</tags>
+    <tags>azure-data-studio</tags>
     <copyright>Microsoft Corporation</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
   </metadata>


### PR DESCRIPTION
Currently the package has three tag: `azure`, `data` and `studio`. This PR changes it to a single tag `azure-data-studio`