### PR TITLE
update chocolatey package to 1.12.1

### DIFF
--- a/azure-data-studio.nuspec
+++ b/azure-data-studio.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>azure-data-studio</id>
     <title>Azure Data Studio</title>
-    <version>1.12.0</version>
+    <version>1.12.1</version>
     <authors>Microsoft</authors>
     <owners>kendaleiv</owners>
     <summary>Azure Data Studio</summary>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -8,11 +8,11 @@ Write-Host "Merge Tasks: `n$mergeTasks"
 $packageArgs = @{
   packageName    = 'azure-data-studio'
   fileType       = 'EXE'
-  url64bit       = 'https://go.microsoft.com/fwlink/?linkid=2105134'
+  url64bit       = 'https://azuredatastudiobuilds.blob.core.windows.net/releases/1.12.1/azuredatastudio-windows-setup-1.12.1.exe'
 
   softwareName   = 'Azure Data Studio'
 
-  checksum64     = 'BA43790B60C06D3290027140FEC159279E9B919C2864E63EB1134D0818DAC644'
+  checksum64     = '103581E77C54F82E6BCECC592FE959541AB2DED7B9591B941C2AC4AA460CCB1E'
   checksumType64 = 'sha256'
 
   silentArgs     = "/verysilent /suppressmsgboxes /mergetasks=""$mergeTasks"" /log=""$env:temp\azure-data-studio.log"""


### PR DESCRIPTION
Use direct azure blob storage link to to close issue #5

The url `'https://go.microsoft.com/fwlink/?linkid=2105134'`  for "System Installer" version of Azure Data Studio resolves to the new url pointing to blob storage.

We should use that URL to avoid the bug where this package pulls the latest patch version and fails because hashes don't match. 

In addition, this also follows the pattern that the vscode package does. You can see it [here]( 
https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/5c68a7b7c19bb031ab9ae4d17cf1c8e18e6b83e9/automatic/vscode/tools/ChocolateyInstall.ps1#L20)